### PR TITLE
New sample API data and moved to a separate file

### DIFF
--- a/src/algorithms/graph-builder.ts
+++ b/src/algorithms/graph-builder.ts
@@ -1,35 +1,4 @@
-import {INode, Node} from '../api/schema/node';
-import {IWay, Way} from '../api/schema/way';
+import data from './sample-api-data';
 
-function randNode(id: number): INode {
-  return new Node({
-    _id : id,
-    loc : {
-      type : 'Point',
-      coordinates : [Math.random() * 10 + 1, Math.random() * 60 + 1]
-    }});
-}
-
-function randWay(id: number, wayNodes: INode[]): IWay {
-  return new Way({
-    _id : id,
-    tags : {
-      highway : 'primary'
-    },
-    loc : {
-      type : 'Polygon',
-      coordinates : [],
-      nodes : wayNodes.map((x: INode) => x._id)
-    }});
-}
-
-const nodes: INode[] = [];
-const ways: IWay[] = [];
-
-for (let i = 0; i < 20; i++) {
-  nodes.push(randNode(i));
-}
-ways.push(randWay(1, nodes));
-
-console.log(nodes);
-console.log(ways);
+console.log(data.nodes);
+console.log(data.ways);

--- a/src/algorithms/sample-api-data.ts
+++ b/src/algorithms/sample-api-data.ts
@@ -1,0 +1,68 @@
+import {INode, Node} from '../api/schema/node';
+import {IWay, Way} from '../api/schema/way';
+
+function getNode(id: number, x: number, y: number): INode {
+  return new Node({
+    _id : id,
+    loc : {
+      type : 'Point',
+      coordinates : [x, y]
+    }});
+}
+
+function getWay(id: number, wayNodes: INode[]): IWay {
+  return new Way({
+    _id : id,
+    tags : {
+      highway : 'primary'
+    },
+    loc : {
+      type : 'Polygon',
+      coordinates : [],
+      nodes : wayNodes.map((x: INode) => x._id)
+    }});
+}
+
+const _nodes: INode[] = [
+  // just to be able to index the array from 1 (according to node ids)
+  null,
+  getNode(1, 4, 1),
+  getNode(2, 4, 2),
+  getNode(3, 4, 3),
+  getNode(4, 4, 4),
+  getNode(5, 4, 5),
+  getNode(6, 5, 5),
+  getNode(7, 6, 5),
+  getNode(8, 7, 5),
+  getNode(9, 1, 3),
+  getNode(10, 2, 4),
+  getNode(11, 2, 5),
+  getNode(12, 3, 5),
+  getNode(13, 2, 3),
+  getNode(14, 3, 3),
+  getNode(15, 5, 3),
+  getNode(16, 6, 3),
+  getNode(17, 7, 3),
+  getNode(18, 7, 2),
+  getNode(19, 6, 2),
+  getNode(20, 7, 1),
+  getNode(21, 8, 1)
+];
+
+const _ways: IWay[] = [
+  getWay(1, [_nodes[1], _nodes[2], _nodes[3], _nodes[4], _nodes[5], _nodes[6], _nodes[7], _nodes[8]]),
+  getWay(2, [_nodes[8], _nodes[7], _nodes[6], _nodes[5], _nodes[4], _nodes[3], _nodes[2], _nodes[1]]),
+  getWay(3, [_nodes[9], _nodes[10], _nodes[11], _nodes[12], _nodes[5]]),
+  getWay(4, [_nodes[9], _nodes[13], _nodes[14], _nodes[3], _nodes[15], _nodes[16]]),
+  getWay(5, [_nodes[16], _nodes[15], _nodes[3], _nodes[14], _nodes[13], _nodes[9]]),
+  getWay(6, [_nodes[17], _nodes[18], _nodes[19], _nodes[16], _nodes[17]]),
+  getWay(7, [_nodes[18], _nodes[20], _nodes[21]]),
+  getWay(8, [_nodes[21], _nodes[20], _nodes[18]])
+];
+
+const data = {
+  nodes: _nodes,
+  ways: _ways
+};
+
+export default data;


### PR DESCRIPTION
I created a sample API data that can be used for simplifying of the graph or building it.

I moved the sample data to a separate file so all of us can use them.

Nodes and ways structure as follows:
![image](https://user-images.githubusercontent.com/11633230/47289745-84208a00-d5fc-11e8-9e0a-7c220395d699.png)

@aroni11 Could you build the sample graph data over this example so we keep it consistent?
